### PR TITLE
fix(panel): expose master_register_token in /api/info and use it in j…

### DIFF
--- a/panel/backend/server.js
+++ b/panel/backend/server.js
@@ -3032,7 +3032,7 @@ async function handleMasterApi(req, res) {
   }
 
   if (req.method === "GET" && urlPath === "/api/info") {
-    sendJson(res, 200, {
+    const info = {
       ok: true,
       role: ROLE,
       local_agent_enabled: LOCAL_AGENT_ENABLED,
@@ -3040,7 +3040,11 @@ async function handleMasterApi(req, res) {
       managed_certificates_enabled: MANAGED_CERTS_ENABLED,
       cf_token_configured: !!CF_TOKEN,
       acme_dns_provider: ACME_DNS_PROVIDER || null,
-    });
+    };
+    if (isPanelAuthorized(req)) {
+      info.master_register_token = MASTER_REGISTER_TOKEN || null;
+    }
+    sendJson(res, 200, info);
     return;
   }
 

--- a/panel/frontend/src/App.vue
+++ b/panel/frontend/src/App.vue
@@ -857,7 +857,7 @@ const joinScriptUrl = computed(() => {
 })
 
 const joinRegisterToken = computed(() => {
-  return ruleStore.token || '<YOUR_TOKEN>'
+  return ruleStore.systemInfo.master_register_token || ruleStore.token || '<YOUR_TOKEN>'
 })
 
 const linuxJoinCommand = computed(() => {


### PR DESCRIPTION
…oin command

When MASTER_REGISTER_TOKEN is configured independently from API_TOKEN, the frontend was showing the panel auth token in the join command, causing a 401 on agent registration.

Changes:
- /api/info now includes master_register_token when the request is panel-authorized (authenticated users only)
- Frontend joinRegisterToken uses systemInfo.master_register_token with fallback to panel token for backwards compatibility