### PR TITLE
@

### DIFF
--- a/panel/backend-go/internal/controlplane/service/traffic_service.go
+++ b/panel/backend-go/internal/controlplane/service/traffic_service.go
@@ -801,6 +801,7 @@ func (s *trafficService) Cleanup(ctx context.Context, agentID string) (TrafficCl
 	cutoff := storage.TrafficCleanupCutoff{}
 	if policy.HourlyRetentionDays > 0 {
 		cutoff.HourlyBefore = storage.LocalHourStart(now.AddDate(0, 0, -policy.HourlyRetentionDays)).UTC()
+		cutoff.EventBefore = cutoff.HourlyBefore
 		cycleStart, cycleEnd := monthlyCycleWindow(now, policy.CycleStartDay)
 		if cutoff.HourlyBefore.After(cycleStart) {
 			protectedStart, ok, err := s.rolloutDayHourlyPreserveStart(ctx, agentID, cycleStart, cycleEnd)
@@ -809,6 +810,7 @@ func (s *trafficService) Cleanup(ctx context.Context, agentID string) (TrafficCl
 			}
 			if ok && cutoff.HourlyBefore.After(protectedStart) {
 				cutoff.HourlyBefore = protectedStart
+				cutoff.EventBefore = protectedStart
 			}
 		}
 	}

--- a/panel/backend-go/internal/controlplane/storage/traffic_store.go
+++ b/panel/backend-go/internal/controlplane/storage/traffic_store.go
@@ -56,6 +56,7 @@ type TrafficCleanupCutoff struct {
 	HourlyBefore  time.Time
 	DailyBefore   time.Time
 	MonthlyBefore time.Time
+	EventBefore   time.Time
 }
 
 type TrafficCursorDeltaResult struct {
@@ -833,6 +834,14 @@ func (s *GormStore) DeleteTrafficBefore(ctx context.Context, agentID string, cut
 		if !cutoff.MonthlyBefore.IsZero() {
 			result := tx.Where("agent_id = ? AND period_start < ?", agentID, formatTrafficTime(cutoff.MonthlyBefore.UTC())).
 				Delete(&AgentTrafficMonthlySummaryRow{})
+			if result.Error != nil {
+				return result.Error
+			}
+			deleted += result.RowsAffected
+		}
+		if !cutoff.EventBefore.IsZero() {
+			result := tx.Where("agent_id = ? AND created_at < ?", agentID, formatTrafficTime(cutoff.EventBefore.UTC())).
+				Delete(&AgentTrafficEventRow{})
 			if result.Error != nil {
 				return result.Error
 			}

--- a/panel/backend-go/internal/controlplane/storage/traffic_store_test.go
+++ b/panel/backend-go/internal/controlplane/storage/traffic_store_test.go
@@ -967,6 +967,91 @@ func TestDeleteTrafficBeforeRemovesExpiredBuckets(t *testing.T) {
 	}
 }
 
+func TestDeleteTrafficBeforeRemovesExpiredEvents(t *testing.T) {
+	store := newTrafficTestStore(t, true)
+	ctx := context.Background()
+	cutoff := time.Date(2026, 5, 3, 8, 0, 0, 0, time.UTC)
+
+	for _, ts := range []time.Time{
+		cutoff.Add(-2 * time.Hour),
+		cutoff.Add(-time.Hour),
+		cutoff.Add(time.Hour),
+	} {
+		if err := store.SaveTrafficEvent(ctx, AgentTrafficEventRow{
+			AgentID:   "edge-1",
+			EventType: "counter_reset",
+			Message:   "old",
+			CreatedAt: formatTrafficTime(ts),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	deleted, err := store.DeleteTrafficBefore(ctx, "edge-1", TrafficCleanupCutoff{
+		EventBefore: cutoff,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", deleted)
+	}
+
+	var remaining int64
+	if err := store.db.WithContext(ctx).
+		Model(&AgentTrafficEventRow{}).
+		Where("agent_id = ?", "edge-1").
+		Count(&remaining).Error; err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 1 {
+		t.Fatalf("remaining = %d, want 1", remaining)
+	}
+}
+
+func TestDeleteTrafficBeforeEventCutoffIsOptional(t *testing.T) {
+	store := newTrafficTestStore(t, true)
+	ctx := context.Background()
+	oldBucket := time.Date(2026, 5, 3, 8, 0, 0, 0, time.UTC)
+
+	if err := store.IncrementTrafficBuckets(ctx, TrafficDelta{
+		AgentID:     "edge-1",
+		ScopeType:   "http_rule",
+		ScopeID:     "11",
+		BucketStart: oldBucket,
+		RXBytes:     1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveTrafficEvent(ctx, AgentTrafficEventRow{
+		AgentID:   "edge-1",
+		EventType: "calibration",
+		Message:   "kept",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	deleted, err := store.DeleteTrafficBefore(ctx, "edge-1", TrafficCleanupCutoff{
+		HourlyBefore: oldBucket.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+
+	var remaining int64
+	if err := store.db.WithContext(ctx).
+		Model(&AgentTrafficEventRow{}).
+		Where("agent_id = ?", "edge-1").
+		Count(&remaining).Error; err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 1 {
+		t.Fatalf("events remaining = %d, want 1", remaining)
+	}
+}
 func TestDeleteTrafficBeforeComparesDailyAndMonthlyPeriodsByInstant(t *testing.T) {
 	store := newTrafficTestStore(t, true)
 	ctx := context.Background()


### PR DESCRIPTION
fix(backend): prune agent_traffic_events by hourly retention

Events now follow HourlyRetentionDays instead of growing unbounded. @