### PR TITLE
fix(backend): ack applied revision despite plugin generation conflict

### DIFF
--- a/panel/backend-go/internal/controlplane/http/router.go
+++ b/panel/backend-go/internal/controlplane/http/router.go
@@ -896,6 +896,8 @@ func mapServiceError(err error) (int, map[string]any) {
 		return http.StatusConflict, revisionErrorPayload(err.Error(), "revision_lease_conflict")
 	case errors.Is(err, coordinator.ErrStateConflict):
 		return http.StatusConflict, errorPayload(err.Error())
+	case errors.Is(err, storage.ErrPluginGenerationStale), errors.Is(err, storage.ErrPluginGenerationConflict):
+		return http.StatusConflict, revisionErrorPayload(err.Error(), "plugin_generation_conflict")
 	case errors.Is(err, service.ErrPKIOperationNotFound):
 		return http.StatusNotFound, errorPayload("PKI operation not found")
 	case errors.Is(err, service.ErrPKILifecycleConflict):

--- a/panel/backend-go/internal/controlplane/service/http_backend_contract_test.go
+++ b/panel/backend-go/internal/controlplane/service/http_backend_contract_test.go
@@ -382,6 +382,16 @@ func TestHeartbeatRevisionRebasesPendingPluginGeneration(t *testing.T) {
 	if _, err := api.ReportRemoteRevision(ctx, "local", report); err != nil {
 		t.Fatalf("ReportRemoteRevision() replay error = %v", err)
 	}
+	inherited := status
+	inherited.InstanceID = "webdav-default"
+	inherited.PluginID = "webdav"
+	inherited.OperationID = "pluginop-webdav-older"
+	inherited.Revision = heartbeatRevision - 6
+	replayWithInherited := report
+	replayWithInherited.PluginStatuses = []storage.PluginRuntimeStatus{status, inherited}
+	if _, err := api.ReportRemoteRevision(ctx, "local", replayWithInherited); err != nil {
+		t.Fatalf("ReportRemoteRevision() inherited plugin replay error = %v", err)
+	}
 
 	installed, found, err = fixture.store.GetInstalledPlugin(ctx, fixture.pluginID)
 	if err != nil || !found || installed.PendingOperationID != "" {

--- a/panel/backend-go/internal/controlplane/service/plugin_lifecycle_reconciler.go
+++ b/panel/backend-go/internal/controlplane/service/plugin_lifecycle_reconciler.go
@@ -152,6 +152,19 @@ func (r *PluginLifecycleReconciler) Reconcile(ctx context.Context, report storag
 	}
 	_, replayed, err := r.store.RecordPluginAgentRuntimeReport(ctx, report)
 	if err != nil {
+		if !errors.Is(err, storage.ErrPluginGenerationStale) && !errors.Is(err, storage.ErrPluginGenerationConflict) {
+			return PluginLifecycleReconcileResult{}, err
+		}
+		operation, found, opErr := r.store.GetPluginOperation(ctx, report.OperationID)
+		if opErr != nil {
+			return PluginLifecycleReconcileResult{}, opErr
+		}
+		if found && (operation.Status == "succeeded" || operation.Status == "failed") {
+			return PluginLifecycleReconcileResult{
+				OperationID: report.OperationID, Replayed: true,
+				Completed: true, Applied: operation.Status == "succeeded",
+			}, nil
+		}
 		return PluginLifecycleReconcileResult{}, err
 	}
 	operation, found, err := r.store.GetPluginOperation(ctx, report.OperationID)

--- a/panel/backend-go/internal/controlplane/service/plugin_lifecycle_reconciler_runtime_test.go
+++ b/panel/backend-go/internal/controlplane/service/plugin_lifecycle_reconciler_runtime_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -172,3 +173,47 @@ func (r *mixedScopeControlPlaneRuntime) ActivateBatch(_ context.Context, candida
 
 func (*mixedScopeControlPlaneRuntime) ActiveGeneration(string) (string, bool) { return "", false }
 func (*mixedScopeControlPlaneRuntime) Stop(context.Context, string) error     { return nil }
+
+func TestPluginLifecycleReconcilerAcksSucceededUpgradeWhenRuntimeReportConflicts(t *testing.T) {
+	t.Parallel()
+
+	digest := strings.Repeat("c", 64)
+	store := &conflictingSucceededLifecycleStore{
+		operation: storage.PluginOperationRow{
+			ID: "pluginop-docker-app", PluginID: "docker-app", Kind: "upgrade", Status: "succeeded",
+			TargetPackageDigest: digest, TargetRevision: 478, ActorID: "admin",
+		},
+	}
+	reconciler, err := NewPluginLifecycleReconciler(store, &mixedScopeLifecycleCompletion{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := reconciler.Reconcile(t.Context(), storage.PluginGenerationReport{
+		OperationID: "pluginop-docker-app", AgentID: "edge-a", InstanceID: "docker-app-default",
+		PluginID: "docker-app", Revision: 478, GenerationID: digest,
+		PackageDigest: digest, ArtifactDigest: digest, State: "active", Sequence: 1,
+		Details: json.RawMessage(`{"sandbox_provider":"linux-reexec-kernel-v1"}`),
+	}, "agent:edge-a")
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if !result.Completed || !result.Applied || !result.Replayed {
+		t.Fatalf("Reconcile() result = %+v", result)
+	}
+}
+
+type conflictingSucceededLifecycleStore struct {
+	operation storage.PluginOperationRow
+}
+
+func (*conflictingSucceededLifecycleStore) RecordPluginAgentRuntimeReport(context.Context, storage.PluginGenerationReport) (storage.PluginAgentRuntimeStatusRow, bool, error) {
+	return storage.PluginAgentRuntimeStatusRow{}, false, storage.ErrPluginGenerationConflict
+}
+
+func (*conflictingSucceededLifecycleStore) ListPluginAgentRuntimeStatuses(context.Context, string) ([]storage.PluginAgentRuntimeStatusRow, error) {
+	return nil, nil
+}
+
+func (s *conflictingSucceededLifecycleStore) GetPluginOperation(context.Context, string) (storage.PluginOperationRow, bool, error) {
+	return s.operation, true, nil
+}

--- a/panel/backend-go/internal/controlplane/service/revision_api.go
+++ b/panel/backend-go/internal/controlplane/service/revision_api.go
@@ -829,7 +829,7 @@ func (s *RevisionAPI) reconcilePluginRevisionReport(ctx context.Context, agentID
 	}); ok {
 		for _, report := range input.PluginLogs {
 			if _, err := logStore.RecordPluginRuntimeLogReport(ctx, agentID, report); err != nil {
-				if errors.Is(err, storage.ErrPluginGenerationStale) {
+				if pluginGenerationReportIgnorable(err) {
 					continue
 				}
 				return err
@@ -837,6 +837,10 @@ func (s *RevisionAPI) reconcilePluginRevisionReport(ctx context.Context, agentID
 		}
 	} else if len(input.PluginLogs) > 0 {
 		return errors.New("plugin runtime log ingestion is unavailable")
+	}
+	revisionRow, found, err := s.repository.GetCoordinatorRevision(ctx, agentID, input.Revision)
+	if err != nil || !found {
+		return err
 	}
 	for _, status := range input.PluginStatuses {
 		report := storage.PluginGenerationReport{
@@ -846,13 +850,9 @@ func (s *RevisionAPI) reconcilePluginRevisionReport(ctx context.Context, agentID
 			ErrorCode: status.ErrorCode, SafeDetail: status.SafeDetail,
 			Details: append(json.RawMessage(nil), status.Details...), Budget: append(json.RawMessage(nil), status.Budget...),
 		}
-		if _, err := s.pluginLifecycle.Reconcile(ctx, report, agentID); err != nil && !errors.Is(err, storage.ErrPluginGenerationStale) {
+		if _, err := s.pluginLifecycle.Reconcile(ctx, report, agentID); err != nil && !pluginGenerationReportIgnorable(err) {
 			return err
 		}
-	}
-	revisionRow, found, err := s.repository.GetCoordinatorRevision(ctx, agentID, input.Revision)
-	if err != nil || !found {
-		return err
 	}
 	rows, err := s.pluginLifecycle.store.ListPluginAgentRuntimeStatuses(ctx, revisionRow.OperationID)
 	if err != nil {
@@ -882,7 +882,7 @@ func (s *RevisionAPI) reconcilePluginRevisionReport(ctx context.Context, agentID
 				ArtifactDigest: row.ArtifactDigest, State: row.State, Sequence: row.ReportSequence,
 				ErrorCode: row.ErrorCode, Details: json.RawMessage(row.DetailsJSON), Budget: json.RawMessage(row.BudgetJSON),
 			}
-			if _, err := s.pluginLifecycle.Reconcile(ctx, report, agentID); err != nil && !errors.Is(err, storage.ErrPluginGenerationStale) {
+			if _, err := s.pluginLifecycle.Reconcile(ctx, report, agentID); err != nil && !pluginGenerationReportIgnorable(err) {
 				return err
 			}
 			continue
@@ -918,11 +918,15 @@ func (s *RevisionAPI) reconcilePluginRevisionReport(ctx context.Context, agentID
 		default:
 			return storage.ErrPluginGenerationConflict
 		}
-		if _, err := s.pluginLifecycle.Reconcile(ctx, report, agentID); err != nil {
+		if _, err := s.pluginLifecycle.Reconcile(ctx, report, agentID); err != nil && !pluginGenerationReportIgnorable(err) {
 			return err
 		}
 	}
 	return nil
+}
+
+func pluginGenerationReportIgnorable(err error) bool {
+	return errors.Is(err, storage.ErrPluginGenerationStale) || errors.Is(err, storage.ErrPluginGenerationConflict)
 }
 
 func (s *RevisionAPI) reconcilePluginRevisionWithoutRuntimeStatuses(ctx context.Context, operationID string) error {

--- a/panel/backend-go/internal/controlplane/storage/plugin_generation.go
+++ b/panel/backend-go/internal/controlplane/storage/plugin_generation.go
@@ -714,6 +714,9 @@ func (s *GormStore) RecordPluginAgentRuntimeReport(ctx context.Context, report P
 	replayed := false
 	err = s.writeTransaction(ctx, func(tx *gorm.DB) error {
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("operation_id = ? AND agent_id = ? AND instance_id = ?", report.OperationID, report.AgentID, report.InstanceID).First(&result).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrPluginGenerationStale
+			}
 			return err
 		}
 		if result.AuthoritySlot == "retired" {

--- a/panel/frontend/src/hooks/useAgentMonitorStream.js
+++ b/panel/frontend/src/hooks/useAgentMonitorStream.js
@@ -2,40 +2,41 @@ import { useQueryClient } from '@tanstack/vue-query'
 import { computed, onScopeDispose, ref, unref, watch } from 'vue'
 import * as api from '../api'
 import { useAuthState } from '../context/useAuthState'
-import { mergeMonitorAgents, monitorSnapshotAgents } from '../utils/agentMonitor'
+import { mergeMonitorAgents, monitorSnapshotAgents, preserveRunningPackage } from '../utils/agentMonitor'
 
 export const AGENT_MONITOR_QUERY_KEY = ['agent-monitor']
 export const AGENT_MONITOR_RECONNECT_DELAY_MS = 2000
 
 function mergeAgentList(previous, monitorAgent) {
   if (!monitorAgent?.id || !Array.isArray(previous)) return previous
-  return previous.map((agent) => agent?.id === monitorAgent.id
-    ? {
-        ...agent,
-        name: monitorAgent.name || agent.name,
-        status: monitorAgent.status || agent.status,
-        last_seen_at: monitorAgent.last_seen_at || agent.last_seen_at,
-        last_seen_ip: monitorAgent.last_seen_ip || agent.last_seen_ip,
-        // DDNS display fields (T7): these must be in the whitelist so a monitor
-        // SSE message that omits them never regresses cached v4/v6/domain/status.
-        last_seen_ipv4: monitorAgent.last_seen_ipv4 || agent.last_seen_ipv4,
-        last_seen_ipv6: monitorAgent.last_seen_ipv6 || agent.last_seen_ipv6,
-        ddns_domain: monitorAgent.ddns_domain || agent.ddns_domain,
-        ddns_status: monitorAgent.ddns_status || agent.ddns_status,
-        version: monitorAgent.version || agent.version,
-        platform: monitorAgent.platform || agent.platform,
-        runtime_package_version: monitorAgent.runtime_package_version || agent.runtime_package_version,
-        runtime_package_platform: monitorAgent.runtime_package_platform || agent.runtime_package_platform,
-        runtime_package_arch: monitorAgent.runtime_package_arch || agent.runtime_package_arch,
-        runtime_package_sha256: monitorAgent.runtime_package_sha256 || agent.runtime_package_sha256,
-        desired_package_sha256: monitorAgent.desired_package_sha256 || agent.desired_package_sha256,
-        package_sync_status: monitorAgent.package_sync_status || agent.package_sync_status,
-        mode: monitorAgent.mode || agent.mode,
-        tags: Array.isArray(monitorAgent.tags) ? monitorAgent.tags : agent.tags,
-        monitor: monitorAgent
-      }
-    : agent
-  )
+  return previous.map((agent) => {
+    if (agent?.id !== monitorAgent.id) return agent
+    const merged = {
+      ...agent,
+      name: monitorAgent.name || agent.name,
+      status: monitorAgent.status || agent.status,
+      last_seen_at: monitorAgent.last_seen_at || agent.last_seen_at,
+      last_seen_ip: monitorAgent.last_seen_ip || agent.last_seen_ip,
+      // DDNS display fields (T7): these must be in the whitelist so a monitor
+      // SSE message that omits them never regresses cached v4/v6/domain/status.
+      last_seen_ipv4: monitorAgent.last_seen_ipv4 || agent.last_seen_ipv4,
+      last_seen_ipv6: monitorAgent.last_seen_ipv6 || agent.last_seen_ipv6,
+      ddns_domain: monitorAgent.ddns_domain || agent.ddns_domain,
+      ddns_status: monitorAgent.ddns_status || agent.ddns_status,
+      version: monitorAgent.version || agent.version,
+      platform: monitorAgent.platform || agent.platform,
+      runtime_package_version: monitorAgent.runtime_package_version || agent.runtime_package_version,
+      runtime_package_platform: monitorAgent.runtime_package_platform || agent.runtime_package_platform,
+      runtime_package_arch: monitorAgent.runtime_package_arch || agent.runtime_package_arch,
+      runtime_package_sha256: monitorAgent.runtime_package_sha256 || agent.runtime_package_sha256,
+      desired_package_sha256: monitorAgent.desired_package_sha256 || agent.desired_package_sha256,
+      package_sync_status: monitorAgent.package_sync_status || agent.package_sync_status,
+      mode: monitorAgent.mode || agent.mode,
+      tags: Array.isArray(monitorAgent.tags) ? monitorAgent.tags : agent.tags,
+      monitor: monitorAgent
+    }
+    return preserveRunningPackage(agent, merged)
+  })
 }
 
 export function applyAgentMonitorMessage(queryClient, message) {

--- a/panel/frontend/src/hooks/useAgentMonitorStream.test.js
+++ b/panel/frontend/src/hooks/useAgentMonitorStream.test.js
@@ -48,6 +48,7 @@ describe('useAgentMonitorStream', () => {
 
   afterEach(() => {
     clearAuthToken()
+    vi.clearAllTimers()
     vi.useRealTimers()
   })
 
@@ -204,7 +205,7 @@ describe('useAgentMonitorStream', () => {
     wrapper.unmount()
   })
 
-  it('updates cached runtime package identity from an upgrade heartbeat', async () => {
+  it('keeps the running package identity while an upgrade heartbeat reports the target digest', async () => {
     const queryClient = createQueryClient()
     queryClient.setQueryData(['agents'], [{
       id: 'edge-1',
@@ -237,11 +238,53 @@ describe('useAgentMonitorStream', () => {
     await vi.dynamicImportSettled()
 
     expect(queryClient.getQueryData(['agents'])[0]).toMatchObject({
+      runtime_package_version: '1.0.0',
+      runtime_package_platform: 'linux',
+      runtime_package_arch: 'amd64',
+      runtime_package_sha256: 'a'.repeat(64),
+      desired_package_sha256: 'b'.repeat(64),
+      package_sync_status: 'pending'
+    })
+    wrapper.unmount()
+  })
+
+  it('accepts a completed upgrade once the cached running digest already matches the target', async () => {
+    const digest = 'b'.repeat(64)
+    const queryClient = createQueryClient()
+    queryClient.setQueryData(['agents'], [{
+      id: 'edge-1',
       runtime_package_version: '2.0.0',
       runtime_package_platform: 'linux',
       runtime_package_arch: 'amd64',
-      runtime_package_sha256: 'b'.repeat(64),
-      desired_package_sha256: 'b'.repeat(64),
+      runtime_package_sha256: digest,
+      desired_package_sha256: digest,
+      package_sync_status: 'aligned'
+    }])
+    api.consumeAgentMonitorStream.mockImplementation(async ({ onMessage }) => {
+      onMessage({
+        type: 'update',
+        payload: {
+          agent: {
+            id: 'edge-1',
+            runtime_package_version: '2.0.0',
+            runtime_package_platform: 'linux',
+            runtime_package_arch: 'amd64',
+            runtime_package_sha256: digest,
+            desired_package_sha256: digest,
+            package_sync_status: 'aligned'
+          }
+        }
+      })
+    })
+
+    const { wrapper } = mountHarness(queryClient, { reconnectDelay: -1 })
+    await nextTick()
+    await vi.dynamicImportSettled()
+
+    expect(queryClient.getQueryData(['agents'])[0]).toMatchObject({
+      runtime_package_version: '2.0.0',
+      runtime_package_sha256: digest,
+      desired_package_sha256: digest,
       package_sync_status: 'aligned'
     })
     wrapper.unmount()

--- a/panel/frontend/src/pages/AgentDetailPage.vue
+++ b/panel/frontend/src/pages/AgentDetailPage.vue
@@ -33,7 +33,7 @@
               <span class="agent-detail__header-meta" data-testid="detail-header-ipv4">{{ detailLabels.ddns.metaIpv4 }} {{ displayIPv4 }}</span>
             </template>
             <span class="agent-detail__identity-sep" aria-hidden="true">·</span>
-            <span class="agent-detail__header-meta" data-testid="detail-header-version">{{ agent.version || agent.runtime_package_version || '—' }}</span>
+            <span class="agent-detail__header-meta" data-testid="detail-header-version">{{ runningPackageVersion }}</span>
           </div>
         </div>
       </template>
@@ -331,12 +331,12 @@
             <div class="info-sections">
               <BaseListCard class="info-card agent-detail__panel agent-detail__panel--inset" :title="detailLabels.systemCards.package" :clickable="false">
                 <div class="info-grid">
-                  <div class="info-row info-row--clean"><span>版本</span><span>{{ agent.version || agent.runtime_package_version || '—' }}</span></div>
+                  <div class="info-row info-row--clean"><span>版本</span><span>{{ runningPackageVersion }}</span></div>
                   <div class="info-row info-row--clean"><span>平台</span><span>{{ agent.runtime_package_platform || agent.platform || '—' }}</span></div>
                   <div class="info-row info-row--clean"><span>架构</span><span>{{ agent.runtime_package_arch || '—' }}</span></div>
-                  <div class="info-row info-row--clean"><span>运行包 SHA</span><span :title="agent.runtime_package_sha256 || ''">{{ shortSha(agent.runtime_package_sha256) }}</span></div>
+                  <div class="info-row info-row--clean"><span>运行包 SHA</span><span :title="runningPackageSha">{{ shortSha(runningPackageSha) }}</span></div>
                   <div class="info-row info-row--clean"><span>目标包 SHA</span><span :title="agent.desired_package_sha256 || ''">{{ shortSha(agent.desired_package_sha256) }}</span></div>
-                  <div class="info-row info-row--clean"><span>包状态</span><span>{{ packageStatusLabel(agent.package_sync_status) }}</span></div>
+                  <div class="info-row info-row--clean"><span>包状态</span><span>{{ packageStatusLabel(runningPackageStatus) }}</span></div>
                 </div>
               </BaseListCard>
 
@@ -657,6 +657,15 @@ const detailLabels = agentDetailLabels
 
 const { data: agentsData, isLoading } = useAgents()
 const agent = computed(() => agentsData.value?.find(a => a.id === agentId.value))
+const runningPackageSha = computed(() => String(agent.value?.runtime_package_sha256 || '').trim())
+const desiredPackageSha = computed(() => String(agent.value?.desired_package_sha256 || '').trim())
+const runningPackageVersion = computed(() => agent.value?.runtime_package_version || agent.value?.version || '—')
+const runningPackageStatus = computed(() => {
+  const running = runningPackageSha.value
+  const desired = desiredPackageSha.value
+  if (running && desired && running.toLowerCase() !== desired.toLowerCase()) return 'pending'
+  return agent.value?.package_sync_status
+})
 const updateAgent = useUpdateAgent()
 const deleteAgent = useDeleteAgent()
 const outboundProxyURL = ref('')

--- a/panel/frontend/src/utils/agentMonitor.js
+++ b/panel/frontend/src/utils/agentMonitor.js
@@ -34,6 +34,47 @@ export function quantizeLastSeenAt(agent) {
   return { ...agent, last_seen_at: date.toISOString() }
 }
 
+function packageSha(value) {
+  return String(value || '').trim()
+}
+
+function samePackageSha(left, right) {
+  const a = packageSha(left)
+  const b = packageSha(right)
+  return Boolean(a) && Boolean(b) && a.toLowerCase() === b.toLowerCase()
+}
+
+// Heartbeats stay alive while a new package is only staged. A monitor payload
+// that copies the target digest into runtime_* would make the panel show the
+// candidate as already running. Keep the last known running identity until
+// the durable agent record itself has switched.
+export function preserveRunningPackage(agent, next) {
+  if (!agent || !next) return next
+  const runningSha = packageSha(agent.runtime_package_sha256)
+  const desiredSha = packageSha(agent.desired_package_sha256 || next.desired_package_sha256)
+  const nextRuntimeSha = packageSha(next.runtime_package_sha256)
+  if (runningSha && desiredSha && !samePackageSha(runningSha, desiredSha) && samePackageSha(nextRuntimeSha, desiredSha)) {
+    return {
+      ...next,
+      runtime_package_sha256: runningSha,
+      runtime_package_version: agent.runtime_package_version,
+      runtime_package_platform: agent.runtime_package_platform,
+      runtime_package_arch: agent.runtime_package_arch,
+      version: agent.version || agent.runtime_package_version,
+      package_sync_status: 'pending'
+    }
+  }
+  if (runningSha && desiredSha && !samePackageSha(runningSha, desiredSha)) {
+    return { ...next, package_sync_status: 'pending' }
+  }
+  return next
+}
+
+export function overlayMonitorOnAgent(agent, monitor) {
+  if (!agent || !monitor) return agent
+  return preserveRunningPackage(agent, { ...agent, ...monitor })
+}
+
 export function mergeMonitorAgents(previous = [], update) {
   const nextAgent = quantizeLastSeenAt(update?.agent || update)
   if (!nextAgent?.id) return Array.isArray(previous) ? previous : []
@@ -55,7 +96,7 @@ export function mergeAgentsWithMonitor(agents, monitorAgents) {
     const monitor = monitorById.get(agent.id) || agent.monitor
     if (!monitor) return agent
     changed = true
-    return { ...agent, ...monitor, monitor }
+    return { ...overlayMonitorOnAgent(agent, monitor), monitor }
   })
   return changed ? merged : baseAgents
 }

--- a/panel/frontend/src/utils/agentMonitor.test.mjs
+++ b/panel/frontend/src/utils/agentMonitor.test.mjs
@@ -88,6 +88,62 @@ describe('agent monitor utils', () => {
       expect(merged[0]).not.toBe(a)
     })
 
+    it('keeps the running package while staging heartbeats report the target digest', () => {
+      const running = 'a'.repeat(64)
+      const target = 'b'.repeat(64)
+      const a = {
+        id: 'edge-1',
+        version: '1.0.0',
+        runtime_package_version: '1.0.0',
+        runtime_package_sha256: running,
+        desired_package_sha256: target,
+        package_sync_status: 'pending'
+      }
+      const monitor = {
+        id: 'edge-1',
+        version: '2.0.0',
+        runtime_package_version: '2.0.0',
+        runtime_package_sha256: target,
+        desired_package_sha256: target,
+        package_sync_status: 'aligned'
+      }
+      const merged = mergeAgentsWithMonitor([a], [monitor])
+      expect(merged[0]).toMatchObject({
+        version: '1.0.0',
+        runtime_package_version: '1.0.0',
+        runtime_package_sha256: running,
+        desired_package_sha256: target,
+        package_sync_status: 'pending'
+      })
+      expect(merged[0].monitor).toEqual(monitor)
+    })
+
+    it('accepts the new running package after the durable agent record has switched', () => {
+      const target = 'b'.repeat(64)
+      const a = {
+        id: 'edge-1',
+        version: '2.0.0',
+        runtime_package_version: '2.0.0',
+        runtime_package_sha256: target,
+        desired_package_sha256: target,
+        package_sync_status: 'aligned'
+      }
+      const merged = mergeAgentsWithMonitor([a], [{
+        id: 'edge-1',
+        version: '2.0.0',
+        runtime_package_version: '2.0.0',
+        runtime_package_sha256: target,
+        desired_package_sha256: target,
+        package_sync_status: 'aligned'
+      }])
+      expect(merged[0]).toMatchObject({
+        version: '2.0.0',
+        runtime_package_version: '2.0.0',
+        runtime_package_sha256: target,
+        package_sync_status: 'aligned'
+      })
+    })
+
     it('falls back to inline agent.monitor when no monitor entry matches', () => {
       const a = { id: 'a', monitor: { status: 'online' } }
       const merged = mergeAgentsWithMonitor([a], [])

--- a/panel/frontend/vite.config.js
+++ b/panel/frontend/vite.config.js
@@ -20,7 +20,6 @@ export default defineConfig({
       'src/pages/outboundProxyURL.test.js',
       'src/utils/agentFilter.test.js',
       'src/utils/agentMetrics.test.js',
-      'src/utils/agentMonitor.test.mjs',
       'src/utils/resolveResourceAgent.test.js',
       'src/utils/resourceCardStatus.test.js',
       'src/utils/trafficStats.test.mjs',


### PR DESCRIPTION
Replay of /api/agent-revisions/{id}/report after a successful plugin upgrade included inherited sibling plugin statuses and reconstructed runtime reports. Unmapped plugin generation conflicts leaked as 500, so Agents kept last_apply_status=error after the revision was already applied.