### PR TITLE
fix(plugins): complete dual-face enable without agent runtime

### DIFF
--- a/panel/backend-go/internal/controlplane/service/plugin_target_authority_test.go
+++ b/panel/backend-go/internal/controlplane/service/plugin_target_authority_test.go
@@ -218,6 +218,38 @@ func TestPluginConfigureAllowsDualFaceEmptyTargetsToFormRemoteAgentGeneration(t 
 	}
 }
 
+func TestPluginEnableCompletesDualFaceEmptyTargetsWithoutAgentRuntime(t *testing.T) {
+	fixture := newPluginTargetAuthorityFixture(t, "official.dual-enable-empty", true)
+	ctx := WithSystemMutationPrincipal(t.Context(), "system:test")
+	request := fixture.configureRequest("edge-a", "dual-enable-instance")
+	request.Targets = []string{}
+	if _, err := fixture.service.ConfigureMutation(ctx, request); err != nil {
+		t.Fatalf("ConfigureMutation() error = %v", err)
+	}
+	if err := fixture.service.reconcilePendingPluginOperation(ctx, fixture.pluginID); err != nil {
+		t.Fatalf("reconcile configure error = %v", err)
+	}
+	if _, err := fixture.service.DisableMutation(ctx, fixture.pluginID, "admin"); err != nil {
+		t.Fatalf("DisableMutation() error = %v", err)
+	}
+	if err := fixture.service.reconcilePendingPluginOperation(ctx, fixture.pluginID); err != nil {
+		t.Fatalf("reconcile disable error = %v", err)
+	}
+	if _, err := fixture.service.EnableMutation(ctx, fixture.pluginID, "admin"); err != nil {
+		t.Fatalf("EnableMutation() error = %v", err)
+	}
+	if err := fixture.service.reconcilePendingPluginOperation(ctx, fixture.pluginID); err != nil {
+		t.Fatalf("reconcile enable error = %v", err)
+	}
+	installed, ok, err := fixture.store.GetInstalledPlugin(ctx, fixture.pluginID)
+	if err != nil || !ok {
+		t.Fatalf("GetInstalledPlugin() ok=%v err=%v", ok, err)
+	}
+	if installed.CurrentLifecycle != "active" || installed.PendingOperationID != "" || installed.PendingKind != "" {
+		t.Fatalf("enabled plugin still pending: %+v", installed)
+	}
+}
+
 func TestPluginConfigureRejectsSecondGlobalControlPlaneInstance(t *testing.T) {
 	fixture := newPluginTargetAuthorityFixture(t, "official.singleton-app", true, true)
 	ctx := WithSystemMutationPrincipal(t.Context(), "system:test")

--- a/panel/backend-go/internal/controlplane/service/plugins.go
+++ b/panel/backend-go/internal/controlplane/service/plugins.go
@@ -1007,7 +1007,7 @@ func (s *PluginService) reconcilePendingPluginOperation(ctx context.Context, plu
 		return err
 	}
 	if len(statuses) == 0 {
-		return s.completePendingConfigureWithoutAgentRuntime(ctx, installed, operation)
+		return s.completePendingOperationWithoutAgentRuntime(ctx, installed, operation)
 	}
 	applied := true
 	terminalStatuses := make([]storage.PluginAgentRuntimeStatusRow, len(statuses))
@@ -1057,29 +1057,37 @@ func (s *PluginService) reconcilePendingPluginOperation(ctx context.Context, plu
 	return err
 }
 
-func (s *PluginService) completePendingConfigureWithoutAgentRuntime(ctx context.Context, installed storage.InstalledPluginRow, operation storage.PluginOperationRow) error {
-	if operation.Kind != "configure" {
+func (s *PluginService) completePendingOperationWithoutAgentRuntime(ctx context.Context, installed storage.InstalledPluginRow, operation storage.PluginOperationRow) error {
+	switch operation.Kind {
+	case "configure", "enable", "disable":
+	default:
 		return nil
 	}
 	instances, err := s.store.ListPluginInstances(ctx, installed.PluginID)
 	if err != nil {
 		return err
 	}
-	foundPending := false
+	foundPendingConfigure := false
 	for _, instance := range instances {
-		if instance.PendingOperationID != operation.ID {
-			continue
-		}
-		foundPending = true
-		targets, err := pluginExplicitTargetIDs(json.RawMessage(instance.PendingTargetJSON))
+		targets, err := pluginExplicitTargetIDs(json.RawMessage(instance.TargetJSON))
 		if err != nil {
 			return err
+		}
+		if strings.TrimSpace(instance.PendingTargetJSON) != "" {
+			pendingTargets, err := pluginExplicitTargetIDs(json.RawMessage(instance.PendingTargetJSON))
+			if err != nil {
+				return err
+			}
+			targets = append(targets, pendingTargets...)
 		}
 		if len(targets) > 0 {
 			return nil
 		}
+		if instance.PendingOperationID == operation.ID {
+			foundPendingConfigure = true
+		}
 	}
-	if !foundPending {
+	if operation.Kind == "configure" && !foundPendingConfigure {
 		return nil
 	}
 	return s.CompleteTrustedRevisionOperation(ctx, operation, true, map[string]any{})
@@ -1117,8 +1125,10 @@ func (s *PluginService) autostartControlPlanePlugin(ctx context.Context, request
 	if err := s.reconcilePendingPluginOperation(ctx, manifest.ID); err != nil {
 		return err
 	}
-	_, err = s.EnableMutation(ctx, manifest.ID, request.ActorID)
-	return err
+	if _, err = s.EnableMutation(ctx, manifest.ID, request.ActorID); err != nil {
+		return err
+	}
+	return s.reconcilePendingPluginOperation(ctx, manifest.ID)
 }
 
 func terminalPluginRuntimeStatus(status storage.PluginAgentRuntimeStatusRow, revision storage.AgentRevisionRow, found bool) (storage.PluginAgentRuntimeStatusRow, bool, bool) {
@@ -1277,17 +1287,27 @@ func (s *PluginService) pluginLifecycleTargetIDs(ctx context.Context, pluginID s
 	if err != nil {
 		return nil, err
 	}
+	implicitRemote, err := s.pluginImplicitRemoteExecution(ctx, pluginID)
+	if err != nil {
+		return nil, err
+	}
+	resolve := func(raw json.RawMessage) ([]string, error) {
+		if implicitRemote {
+			return pluginExplicitTargetIDs(raw)
+		}
+		return pluginTargetIDs(raw, defaultTargetID)
+	}
 	if configure != nil && configure.PublishDesiredEnabled {
 		payload, err := json.Marshal(configure.Targets)
 		if err != nil {
 			return nil, err
 		}
-		requested, err := pluginTargetIDs(payload, defaultTargetID)
+		requested, err := resolve(payload)
 		if err != nil {
 			return nil, err
 		}
 		ids := uniqueAgentIDs(requested)
-		if len(ids) == 0 {
+		if len(ids) == 0 && !implicitRemote {
 			ids = []string{defaultTargetID}
 		}
 		return ids, nil
@@ -1298,13 +1318,13 @@ func (s *PluginService) pluginLifecycleTargetIDs(ctx context.Context, pluginID s
 	}
 	ids := make([]string, 0)
 	for _, instance := range instances {
-		active, err := pluginTargetIDs(json.RawMessage(instance.TargetJSON), defaultTargetID)
+		active, err := resolve(json.RawMessage(instance.TargetJSON))
 		if err != nil {
 			return nil, err
 		}
 		ids = append(ids, active...)
 		if strings.TrimSpace(instance.PendingTargetJSON) != "" {
-			pending, err := pluginTargetIDs(json.RawMessage(instance.PendingTargetJSON), defaultTargetID)
+			pending, err := resolve(json.RawMessage(instance.PendingTargetJSON))
 			if err != nil {
 				return nil, err
 			}
@@ -1316,17 +1336,33 @@ func (s *PluginService) pluginLifecycleTargetIDs(ctx context.Context, pluginID s
 		if err != nil {
 			return nil, err
 		}
-		requested, err := pluginTargetIDs(payload, defaultTargetID)
+		requested, err := resolve(payload)
 		if err != nil {
 			return nil, err
 		}
 		ids = append(ids, requested...)
 	}
 	ids = uniqueAgentIDs(ids)
-	if len(ids) == 0 {
+	if len(ids) == 0 && !implicitRemote {
 		ids = []string{defaultTargetID}
 	}
 	return ids, nil
+}
+
+func (s *PluginService) pluginImplicitRemoteExecution(ctx context.Context, pluginID string) (bool, error) {
+	installed, ok, err := s.store.GetInstalledPlugin(ctx, pluginID)
+	if err != nil || !ok {
+		return false, err
+	}
+	packageRow, exists, err := s.storedPackage(ctx, installed.ActivePackageIdentity, installed.ActivePackageDigest)
+	if err != nil || !exists {
+		return false, err
+	}
+	var manifest plugins.Manifest
+	if err := json.Unmarshal([]byte(packageRow.ManifestJSON), &manifest); err != nil {
+		return false, err
+	}
+	return pluginsdk.RuntimeImplicitRemoteAgentExecution(manifest.Runtime), nil
 }
 
 func pluginLifecycleTargetRevision(revisions map[string]int64, fallback int64) int64 {


### PR DESCRIPTION
Empty-target control-plane plugins were stuck applying after autostart enable because reconcile only completed configure. Enable and disable now finish when no instance lists explicit Agent targets, and autostart reconciles after enable.